### PR TITLE
Add Benchmark Workflow Permissions

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -1,4 +1,6 @@
 name: Run Benchmarks
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/vsanthanam/JBird/security/code-scanning/1](https://github.com/vsanthanam/JBird/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only needs to read the repository contents (e.g., for checking out the code), we will set `contents: read`. This ensures that the workflow has the minimal permissions required to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
