### PR TITLE
Add wrapper `JBird` module to Xcode, Xcode Build CI, XCFramework, Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,44 +72,9 @@ jobs:
   build-xcode:
     strategy:
       matrix:
-        include:
-          - platform: macos
-            scheme: JBirdCore
-            displayName: macOS, JBirdCore
-          - platform: macos
-            scheme: JBirdBuilders
-            displayName: macOS, JBirdBuilders
-          - platform: maccatalyst
-            scheme: JBirdCore
-            displayName: Catalyst, JBirdCore
-          - platform: maccatalyst
-            scheme: JBirdBuilders
-            displayName: Catalyst, JBirdBuilders
-          - platform: ios
-            scheme: JBirdCore
-            displayName: iOS, JBirdCore
-          - platform: ios
-            scheme: JBirdBuilders
-            displayName: iOS, JBirdBuilders
-          - platform: watchos
-            scheme: JBirdCore
-            displayName: watchOS, JBirdCore
-          - platform: watchos
-            scheme: JBirdBuilders
-            displayName: watchOS, JBirdBuilders
-          - platform: tvos
-            scheme: JBirdCore
-            displayName: tvOS, JBirdCore
-          - platform: tvos
-            scheme: JBirdBuilders
-            displayName: tvOS, JBirdBuilders
-          - platform: visionos
-            scheme: JBirdCore
-            displayName: visionOS, JBirdCore
-          - platform: visionos
-            scheme: JBirdBuilders
-            displayName: visionOS, JBirdBuilders
-    name: Build with Xcode (${{ matrix.displayName }})
+        platform: [macos, maccatalyst, ios, watchos, tvos, visionos]
+        scheme: [JBird, JBirdCore, JBirdBuilders]
+    name: Build with Xcode (${{ matrix.platform }}, ${{ matrix.scheme }})
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: macos-15
@@ -247,9 +212,7 @@ jobs:
   build-xcframework:
     strategy:
       matrix:
-        include:
-          - target: JBirdCore
-          - target: JBirdBuilders
+        target: [JBird, JBirdCore, JBirdBuilders]
     name: Build XCFramework (${{ matrix.target }})
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -8,7 +8,7 @@ jobs:
   build-xcframework:
     strategy:
       matrix:
-        target: [JBirdCore, JBirdBuilders]
+        target: [JBird, JBirdCore, JBirdBuilders]
     name: Build XCFramework (${{ matrix.target }})
     runs-on: macos-15
     outputs:
@@ -30,7 +30,7 @@ jobs:
     needs: build-xcframework
     strategy:
       matrix:
-        target: [JBirdCore, JBirdBuilders]
+        target: [JBird, JBirdCore, JBirdBuilders]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/JBird.xcodeproj/project.pbxproj
+++ b/JBird.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		0782A3B92DECCDDB00CE9465 /* JBirdParser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 078952402DDAA08900B53A96 /* JBirdParser.framework */; };
 		0782A3BA2DECCDDB00CE9465 /* JBirdParser.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 078952402DDAA08900B53A96 /* JBirdParser.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0782A3CE2DECCE1500CE9465 /* JBirdCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0782A3902DECCDA500CE9465 /* JBirdCore.framework */; };
+		07FE9CDF2DF344730033B758 /* JBirdBuilders.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0782A3C32DECCDF600CE9465 /* JBirdBuilders.framework */; };
+		07FE9CE42DF344780033B758 /* JBirdCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0782A3902DECCDA500CE9465 /* JBirdCore.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -21,6 +23,20 @@
 			remoteInfo = JBirdParser;
 		};
 		0782A3D02DECCE1500CE9465 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 078951DB2DDAA01700B53A96 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0782A38F2DECCDA500CE9465;
+			remoteInfo = JBirdCore;
+		};
+		07FE9CE12DF344730033B758 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 078951DB2DDAA01700B53A96 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0782A3C22DECCDF600CE9465;
+			remoteInfo = JBirdBuilders;
+		};
+		07FE9CE62DF344780033B758 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 078951DB2DDAA01700B53A96 /* Project object */;
 			proxyType = 1;
@@ -47,6 +63,7 @@
 		0782A3902DECCDA500CE9465 /* JBirdCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JBirdCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0782A3C32DECCDF600CE9465 /* JBirdBuilders.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JBirdBuilders.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		078952402DDAA08900B53A96 /* JBirdParser.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JBirdParser.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		07FE9CD32DF3440A0033B758 /* JBird.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JBird.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -81,6 +98,12 @@
 			path = Sources/JBirdBuilders;
 			sourceTree = "<group>";
 		};
+		07FE9CDC2DF3446B0033B758 /* JBird */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			name = JBird;
+			path = Sources/JBird;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,6 +130,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		07FE9CD02DF3440A0033B758 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				07FE9CDF2DF344730033B758 /* JBirdBuilders.framework in Frameworks */,
+				07FE9CE42DF344780033B758 /* JBirdCore.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -115,6 +147,7 @@
 			children = (
 				0789525B2DDAA10000B53A96 /* Frameworks */,
 				078951E52DDAA01700B53A96 /* Products */,
+				07FE9CDC2DF3446B0033B758 /* JBird */,
 				07DAD5552DF0E67800A3E6DD /* JBirdCore */,
 				07DAD56F2DF0E6B800A3E6DD /* JBirdBuilders */,
 				07DAD5692DF0E69E00A3E6DD /* JBirdParser */,
@@ -127,6 +160,7 @@
 				078952402DDAA08900B53A96 /* JBirdParser.framework */,
 				0782A3902DECCDA500CE9465 /* JBirdCore.framework */,
 				0782A3C32DECCDF600CE9465 /* JBirdBuilders.framework */,
+				07FE9CD32DF3440A0033B758 /* JBird.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -156,6 +190,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		0789523B2DDAA08900B53A96 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		07FE9CCE2DF3440A0033B758 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -237,6 +278,31 @@
 			productReference = 078952402DDAA08900B53A96 /* JBirdParser.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		07FE9CD22DF3440A0033B758 /* JBird */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 07FE9CD92DF3440A0033B758 /* Build configuration list for PBXNativeTarget "JBird" */;
+			buildPhases = (
+				07FE9CCE2DF3440A0033B758 /* Headers */,
+				07FE9CCF2DF3440A0033B758 /* Sources */,
+				07FE9CD02DF3440A0033B758 /* Frameworks */,
+				07FE9CD12DF3440A0033B758 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				07FE9CE22DF344730033B758 /* PBXTargetDependency */,
+				07FE9CE72DF344780033B758 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				07FE9CDC2DF3446B0033B758 /* JBird */,
+			);
+			name = JBird;
+			packageProductDependencies = (
+			);
+			productName = JBird;
+			productReference = 07FE9CD32DF3440A0033B758 /* JBird.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -254,6 +320,9 @@
 						CreatedOnToolsVersion = 16.3;
 					};
 					0789523F2DDAA08900B53A96 = {
+						CreatedOnToolsVersion = 16.3;
+					};
+					07FE9CD22DF3440A0033B758 = {
 						CreatedOnToolsVersion = 16.3;
 					};
 				};
@@ -275,6 +344,7 @@
 				0789523F2DDAA08900B53A96 /* JBirdParser */,
 				0782A38F2DECCDA500CE9465 /* JBirdCore */,
 				0782A3C22DECCDF600CE9465 /* JBirdBuilders */,
+				07FE9CD22DF3440A0033B758 /* JBird */,
 			);
 		};
 /* End PBXProject section */
@@ -295,6 +365,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		0789523E2DDAA08900B53A96 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		07FE9CD12DF3440A0033B758 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -325,6 +402,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		07FE9CCF2DF3440A0033B758 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -337,6 +421,16 @@
 			isa = PBXTargetDependency;
 			target = 0782A38F2DECCDA500CE9465 /* JBirdCore */;
 			targetProxy = 0782A3D02DECCE1500CE9465 /* PBXContainerItemProxy */;
+		};
+		07FE9CE22DF344730033B758 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0782A3C22DECCDF600CE9465 /* JBirdBuilders */;
+			targetProxy = 07FE9CE12DF344730033B758 /* PBXContainerItemProxy */;
+		};
+		07FE9CE72DF344780033B758 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0782A38F2DECCDA500CE9465 /* JBirdCore */;
+			targetProxy = 07FE9CE62DF344780033B758 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -747,6 +841,100 @@
 			};
 			name = Release;
 		};
+		07FE9CD72DF3440A0033B758 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 3FJXDZ3HU4;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = com.jbird.JBird;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_MODULE = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,7";
+				TVOS_DEPLOYMENT_TARGET = 16.0;
+				WATCHOS_DEPLOYMENT_TARGET = 9.0;
+				XROS_DEPLOYMENT_TARGET = 1.0;
+			};
+			name = Debug;
+		};
+		07FE9CD82DF3440A0033B758 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 3FJXDZ3HU4;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = com.jbird.JBird;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_MODULE = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,7";
+				TVOS_DEPLOYMENT_TARGET = 16.0;
+				WATCHOS_DEPLOYMENT_TARGET = 9.0;
+				XROS_DEPLOYMENT_TARGET = 1.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -782,6 +970,15 @@
 			buildConfigurations = (
 				078952502DDAA08900B53A96 /* Debug */,
 				078952512DDAA08900B53A96 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		07FE9CD92DF3440A0033B758 /* Build configuration list for PBXNativeTarget "JBird" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				07FE9CD72DF3440A0033B758 /* Debug */,
+				07FE9CD82DF3440A0033B758 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Sources/JBird/JBird.swift
+++ b/Sources/JBird/JBird.swift
@@ -25,6 +25,8 @@
 
 @_exported import JBirdBuilders
 @_exported import JBirdCore
-@_exported import JBirdMacros
+#if SWIFT_PACKAGE
+    @_exported import JBirdMacros
+#endif
 
 enum JBirdEnum {}


### PR DESCRIPTION
This target does not include the macros, excludec with `#if SWIFT_PACKAGE`, since XCFramework does not support Swift Macros
