### PR TITLE
Remove / simplify generic subscripting APIs

### DIFF
--- a/Sources/JBirdCore/Errors/JSONDeserializationError.swift
+++ b/Sources/JBirdCore/Errors/JSONDeserializationError.swift
@@ -34,7 +34,7 @@ import Foundation
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
 public enum JSONDeserializationError: Error, Equatable, Sendable, CustomStringConvertible {
 
-    // MARK: - Cases
+    // MARK: - API
 
     case illegalFragment
 

--- a/Sources/JBirdCore/Errors/JSONError.swift
+++ b/Sources/JBirdCore/Errors/JSONError.swift
@@ -29,7 +29,7 @@ import Foundation
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
 public enum JSONError: Error, Equatable, Sendable, CustomStringConvertible {
 
-    // MARK: - Cases
+    // MARK: - API
 
     /// Thrown when a subscript is incompatible with a JSON model
     case invalidSubscript(JSON.Subscript)

--- a/Sources/JBirdCore/Errors/JSONSerializationError.swift
+++ b/Sources/JBirdCore/Errors/JSONSerializationError.swift
@@ -29,7 +29,7 @@ import Foundation
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
 public enum JSONSerializationError: Error, CustomStringConvertible {
 
-    // MARK: - Cases
+    // MARK: - API
 
     /// Thrown when serializing an invalid floating point value, e.g. infinity
     case invalidFloat

--- a/Sources/JBirdCore/JBirdCore.docc/Extensions/JSON.md
+++ b/Sources/JBirdCore/JBirdCore.docc/Extensions/JSON.md
@@ -119,7 +119,7 @@ let steve: JSON = [
 - ``subscript(_:as:)-(JSON.Subscript...,_)``
 - ``subscript(_:as:)-(PathComponent,_)``
 
-### Working with JSON objects
+### Working with JSON objects and arrays
 
 - ``keys``
 - ``values``
@@ -130,6 +130,8 @@ let steve: JSON = [
 - ``merge(_:uniquingKeysWith:)``
 - ``merging(_:uniquingKeysWith:)``
 - ``filter(_:)-(([String:JSON].Element)->Bool)``
+- ``filterKeys(_:)``
+- ``filterValues(_:)``
 - ``allSatisfy(_:)-(([String:JSON].Element)->Bool)``
 - ``map(_:)-(([String:JSON].Element)->T)``
 - ``mapValues(_:)``
@@ -138,9 +140,6 @@ let steve: JSON = [
 - ``reduce(into:_:)-(_,(Result,[String:JSON].Element)->Void)``
 - ``reduce(_:_:)-(_,(Result,[String:JSON].Element)->Result)``
 - ``forEach(_:)-(([String:JSON].Element)->Void)``
-
-### Working with JSON arrays
-
 - ``first``
 - ``last``
 - ``value(atIndex:)``
@@ -162,6 +161,7 @@ let steve: JSON = [
 - ``reduce(into:_:)-(_,(Result,JSON)->Void)``
 - ``reduce(_:_:)-(_,(Result,JSON)->Result)``
 - ``forEach(_:)-((JSON)->Void)``
+- ``filterNils()``
 
 ### Deserialization
 

--- a/Sources/JBirdCore/Models/JSON.swift
+++ b/Sources/JBirdCore/Models/JSON.swift
@@ -308,7 +308,7 @@ public enum JSON: Equatable, Hashable, Sendable, ExpressibleByBooleanLiteral, Ex
     /// - Parameter key: A string key to use for lookup
     /// - Returns: The JSON value at the specified key
     public func value(
-        forKey key: some StringProtocol
+        forKey key: String
     ) throws -> JSON {
         try value(forSubscript: .key(key))
     }
@@ -317,7 +317,7 @@ public enum JSON: Equatable, Hashable, Sendable, ExpressibleByBooleanLiteral, Ex
     /// - Parameter index: An integer index to use for lookup
     /// - Returns: The JSON value at the specified index
     public func value(
-        atIndex index: some BinaryInteger
+        atIndex index: Int
     ) throws -> JSON {
         try value(forSubscript: .index(index))
     }
@@ -390,7 +390,7 @@ public enum JSON: Equatable, Hashable, Sendable, ExpressibleByBooleanLiteral, Ex
     /// - Parameter key: The key
     /// - Returns: `true` if the object contains the provided key, `false` if the object does not contain the provided key, or if the JSON value is not an object
     public func containsValue(
-        forKey key: some StringProtocol
+        forKey key: String
     ) -> Bool {
         let `subscript` = Subscript.key(key)
         return containsValue(forSubscript: `subscript`)
@@ -400,7 +400,7 @@ public enum JSON: Equatable, Hashable, Sendable, ExpressibleByBooleanLiteral, Ex
     /// - Parameter index: The index
     /// - Returns: `true` if the array contains the provided index, `false` if the object does not contain the provided index, or if the JSON value is not an array
     public func containsValue(
-        atIndex index: some BinaryInteger
+        atIndex index: Int
     ) -> Bool {
         let `subscript` = Subscript.index(index)
         return containsValue(forSubscript: `subscript`)
@@ -442,7 +442,7 @@ public enum JSON: Equatable, Hashable, Sendable, ExpressibleByBooleanLiteral, Ex
     ///   - key: A string key to use for lookup
     public mutating func setValue(
         _ value: JSON,
-        forKey key: some StringProtocol
+        forKey key: String
     ) throws {
         try setValue(value, forSubscript: .key(key))
     }
@@ -453,7 +453,7 @@ public enum JSON: Equatable, Hashable, Sendable, ExpressibleByBooleanLiteral, Ex
     ///   - index: An integer index to use for lookup
     public mutating func setValue(
         _ value: JSON,
-        atIndex index: some BinaryInteger
+        atIndex index: Int
     ) throws {
         try setValue(value, forSubscript: .index(index))
     }
@@ -732,7 +732,7 @@ public enum JSON: Equatable, Hashable, Sendable, ExpressibleByBooleanLiteral, Ex
     /// Remove the value at the provided key from a JSON object
     /// - Parameter key: The key to remove
     public mutating func removeValue(
-        forKey key: some StringProtocol
+        forKey key: String
     ) throws {
         let `subscript` = Subscript.key(key)
         try removeValue(forSubscript: `subscript`)
@@ -741,7 +741,7 @@ public enum JSON: Equatable, Hashable, Sendable, ExpressibleByBooleanLiteral, Ex
     /// Remove the value at the provided index from a JSON array
     /// - Parameter index: The index to remove
     public mutating func removeValue(
-        atIndex index: some BinaryInteger
+        atIndex index: Int
     ) throws {
         let `subscript` = Subscript.index(index)
         try removeValue(forSubscript: `subscript`)
@@ -797,13 +797,35 @@ public enum JSON: Equatable, Hashable, Sendable, ExpressibleByBooleanLiteral, Ex
         try .object(objectValue.merging(other.objectValue, uniquingKeysWith: combine))
     }
 
-    /// Returns a new JSON object containing the key-value pairs of the object that satisfy the given predicate
+    /// Returns a new JSON object containing the key-value pairs of this object that satisfy the given predicate
     /// - Parameter isIncluded: A closure that takes a key-value pair as its argument and returns a Boolean value indicating whether the pair should be included in the returned JSON object.
     /// - Returns: The filtered JSON object
     public func filter(
         _ isIncluded: (Dictionary<String, JSON>.Element) throws -> Bool
     ) throws -> JSON {
         try .object(objectValue.filter(isIncluded))
+    }
+
+    /// Returns a new JSON object containing the key-value pairs of this object who's keys satisfy the given predicate
+    /// - Parameter isIncluded: A closure that takes a JSON key as its argument and returns a Boolean value indicating whether the key should be included in the returned JSON object.
+    /// - Returns: The filtered JSON object
+    public func filterKeys(
+        _ isIncluded: (String) throws -> Bool
+    ) throws -> JSON {
+        try filter { key, _ in
+            try isIncluded(key)
+        }
+    }
+
+    /// Returns a new JSON object containing the key-value pairs of this object who's values satisfy the given predicate
+    /// - Parameter isIncluded: A closure that takes a JSON object as its argument and returns a Boolean value indicating whether the value should be included in the returned JSON object.
+    /// - Returns: The filtered JSON object
+    public func filterValues(
+        _ isIncluded: (JSON) throws -> Bool
+    ) throws -> JSON {
+        try filter { _, value in
+            try isIncluded(value)
+        }
     }
 
     /// Returns a new JSON value containing the elements of the array that satisfy the given predicate
@@ -813,6 +835,19 @@ public enum JSON: Equatable, Hashable, Sendable, ExpressibleByBooleanLiteral, Ex
         _ isIncluded: (JSON) throws -> Bool
     ) throws -> JSON {
         try .array(arrayValue.filter(isIncluded))
+    }
+
+    public func filterNils() throws -> JSON {
+        switch self {
+        case .array:
+            try filter { value in value != nil }
+        case .object:
+            try filterValues { value in value != nil }
+        case .number,
+             .literal,
+             .string:
+            throw JSONError.illegalCollectionConversion
+        }
     }
 
     /// Remove the value at the provided subscript

--- a/Sources/JBirdCore/Models/Literal.swift
+++ b/Sources/JBirdCore/Models/Literal.swift
@@ -41,7 +41,7 @@ extension JSON {
             self = convertible.jsonLiteral
         }
 
-        // MARK: - Cases
+        // MARK: - API
 
         /// A `true` literal
         case `true`
@@ -51,8 +51,6 @@ extension JSON {
 
         /// A `null` literal
         case null
-
-        // MARK: - API
 
         /// The value as a Swift `bool`
         public var boolValue: Bool {

--- a/Sources/JBirdCore/Models/Number.swift
+++ b/Sources/JBirdCore/Models/Number.swift
@@ -39,13 +39,11 @@ extension JSON {
             self = convertible.jsonNumber
         }
 
-        // MARK: - Cases
+        // MARK: - API
 
         case int(Int)
 
         case double(Double)
-
-        // MARK: - API
 
         /// The number value as a Swift integer
         public var intValue: Int {

--- a/Sources/JBirdCore/Models/Subscript.swift
+++ b/Sources/JBirdCore/Models/Subscript.swift
@@ -41,22 +41,6 @@ extension JSON {
 
         // MARK: - API
 
-        @_disfavoredOverload
-        public static func key(
-            _ key: some StringProtocol
-        ) -> Subscript {
-            Subscript.key(String(key))
-        }
-
-        @_disfavoredOverload
-        public static func index(
-            _ key: some BinaryInteger
-        ) -> Subscript {
-            Subscript.index(Int(key))
-        }
-
-        // MARK: - Cases
-
         /// A key subscript
         case key(String)
 

--- a/Tests/JBirdCoreTests/Models/SubscriptTests.swift
+++ b/Tests/JBirdCoreTests/Models/SubscriptTests.swift
@@ -29,20 +29,6 @@ import Testing
 @Suite("Subscript Tests")
 struct SubscriptTests {
 
-    @Test("StringProtocol Type Method")
-    func stringProtocolTypeMethod() {
-        let str: Substring = "foo"
-        let key = JSON.Subscript.key(str)
-        #expect(key == .key("foo"))
-    }
-
-    @Test("BinaryInteger Type Method")
-    func binaryIntegerTypeMethod() {
-        let int: UInt32 = 12
-        let index = JSON.Subscript.index(int)
-        #expect(index == .index(12))
-    }
-
     @Test("SubscriptConvertibleInit")
     func subscriptConvertibleInit() {
         let key = JSON.Subscript("foo")


### PR DESCRIPTION
- Remove most APIs that accept `some BinaryInteger` and `some StringProtocol` -- these need to be rethought a bit to be done correctly
- Add new `filterKeys`, `filterValues` and `filterNils` APIs
- Unify collection methods under a single DocC header, given that `filterNils` apply to both objects and arrays.