### PR TITLE
Make number encoding/decoding more fault tolerant

### DIFF
--- a/Sources/JBird/JBird.docc/Articles/WhyJBird.md
+++ b/Sources/JBird/JBird.docc/Articles/WhyJBird.md
@@ -61,9 +61,9 @@ JBird provides a fully typed `JSON` enum that accurately represents JSON's data 
 ```swift
 // JBird approach
 let json = try JSON(data)
-let name = try json["user"]["name"].stringValue
-let age = try json["user"]["age"].intValue
-let isActive = try json["user"]["isActive"].boolValue
+let name = try json["user"]["name"].decode(into: String.self)
+let age = try json["user"]["age"].decode(into: Int.self)
+let isActive = try json["user"]["isActive"].decode(into: Bool.self)
 let user = try json["user"].decode(into: User.self)
 ```
 

--- a/Sources/JBirdCore/JBirdCore.docc/Extensions/JSON.md
+++ b/Sources/JBirdCore/JBirdCore.docc/Extensions/JSON.md
@@ -87,6 +87,7 @@ let steve: JSON = [
 - ``stringValue``
 - ``arrayValue``
 - ``objectValue``
+- ``untyped``
 - ``unboxed()``
 - ``decode(into:)``
 

--- a/Sources/JBirdCore/JBirdCore.docc/Extensions/Literal.md
+++ b/Sources/JBirdCore/JBirdCore.docc/Extensions/Literal.md
@@ -53,7 +53,8 @@ if literal.isNull {
 
 ### Initializers
 
-- ``init(_:)``
+- ``init(_:)-(JSONLiteralEncodable)``
+- ``init(_:)-(JSONLiteralConvertible)``
 
 ### Decoding literal values into Swift types
 

--- a/Sources/JBirdCore/JBirdCore.docc/Extensions/Number.md
+++ b/Sources/JBirdCore/JBirdCore.docc/Extensions/Number.md
@@ -58,7 +58,8 @@ if number.isDouble {
 
 ### Initializers
 
-- ``init(_:)``
+- ``init(_:)-(JSONNumberEncodable)``
+- ``init(_:)-(JSONNumberConvertible)``
 
 ### Decoding number values into Swift types
 

--- a/Sources/JBirdCore/JBirdCore.docc/JBirdCore.md
+++ b/Sources/JBirdCore/JBirdCore.docc/JBirdCore.md
@@ -20,6 +20,12 @@ APIs to create, deserialize, manipulate, and serialize JSON data in Swift
 - ``JSONEncodable``
 - ``JSONDecodable``
 - ``JSONCodable``
+- ``JSONNumberEncodable``
+- ``JSONNumberDecodable``
+- ``JSONNumberCodable``
+- ``JSONLiteralEncodable``
+- ``JSONLiteralDecodable``
+- ``JSONLiteralCodable``
 - ``JSONLiteralConvertible``
 - ``JSONNumberConvertible``
 

--- a/Sources/JBirdCore/Models/Literal.swift
+++ b/Sources/JBirdCore/Models/Literal.swift
@@ -29,16 +29,26 @@ import Foundation
 extension JSON {
 
     /// A JSON literal
-    public enum Literal: String, Equatable, Hashable, Sendable, ExpressibleByBooleanLiteral, ExpressibleByNilLiteral, CustomStringConvertible {
+    public enum Literal: Equatable, Hashable, Sendable, ExpressibleByBooleanLiteral, ExpressibleByNilLiteral, CustomStringConvertible {
 
         // MARK: - Initializers
 
         /// Create a literal from a `JSONLiteralConvertible`-conforming tyoe
         /// - Parameter convertible: The convertible type
+        @available(*, deprecated, renamed: "init(_:)", message: "Use `init(_:)` instead")
+        @_disfavoredOverload
         public init(
             _ convertible: some JSONLiteralConvertible
         ) {
             self = convertible.jsonLiteral
+        }
+
+        /// Create a `JSON.Literal` value from a ``JSONLiteralEncodable`` type
+        /// - Parameter encodable: The encodable type to convert to a JSON literal
+        public init(
+            _ encodable: some JSONLiteralEncodable
+        ) {
+            self = encodable.encodeToJSONLiteral()
         }
 
         // MARK: - API
@@ -137,7 +147,14 @@ extension JSON {
         // MARK: - CustomStringConvertible
 
         public var description: String {
-            rawValue
+            switch self {
+            case .true:
+                "true"
+            case .false:
+                "false"
+            case .null:
+                "null"
+            }
         }
     }
 

--- a/Sources/JBirdCore/Models/Number.swift
+++ b/Sources/JBirdCore/Models/Number.swift
@@ -33,10 +33,18 @@ extension JSON {
 
         // MARK: - Initializers
 
+        @available(*, deprecated, renamed: "init(_:)", message: "")
+        @_disfavoredOverload
         public init(
             _ convertible: some JSONNumberConvertible
         ) {
             self = convertible.jsonNumber
+        }
+
+        /// Create a `JSON.Number` value from a ``JSONNumberEncodable`` type
+        /// - Parameter encodable: The encodable type to convert to a JSON number
+        public init(_ encodable: some JSONNumberEncodable) {
+            self = encodable.encodeToJSONNumber()
         }
 
         // MARK: - API

--- a/Sources/JBirdCore/Protocols/JSONCodable.swift
+++ b/Sources/JBirdCore/Protocols/JSONCodable.swift
@@ -66,69 +66,89 @@ extension JSON: JSONCodable {
 }
 
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension Bool: JSONCodable {
+extension JSONEncodable where Self: JSONLiteralEncodable {
 
     public func encodeToJSON() -> JSON {
-        self ? .literal(.true) : .literal(.false)
-    }
-
-    public init(json: JSON) throws {
-        self = try json.boolValue
+        let literal = JSON.Literal(self)
+        return .literal(literal)
     }
 
 }
 
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension JSON.Literal: JSONCodable {
-
-    public func encodeToJSON() -> JSON {
-        .literal(self)
-    }
+extension JSONDecodable where Self: JSONLiteralDecodable {
 
     public init(json: JSON) throws {
-        self = try json.literalValue
+        let literal = try json.literalValue
+        try self.init(jsonLiteral: literal)
     }
 
 }
 
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension Int: JSONCodable {
+extension JSON.Literal: JSONCodable {}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Bool: JSONCodable {}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension JSONEncodable where Self: JSONNumberEncodable {
 
     public func encodeToJSON() -> JSON {
-        .number(.int(self))
-    }
-
-    public init(json: JSON) throws {
-        self = try json.intValue
+        let number = JSON.Number(self)
+        return .number(number)
     }
 
 }
 
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension Double: JSONCodable {
-
-    public func encodeToJSON() -> JSON {
-        .number(.double(self))
-    }
+extension JSONDecodable where Self: JSONNumberDecodable {
 
     public init(json: JSON) throws {
-        self = try json.doubleValue
+        let number = try json.numberValue
+        try self.init(jsonNumber: number)
     }
 
 }
 
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension JSON.Number: JSONCodable {
+extension JSON.Number: JSONCodable {}
 
-    public func encodeToJSON() -> JSON {
-        .number(self)
-    }
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Int: JSONCodable {}
 
-    public init(json: JSON) throws {
-        self = try json.numberValue
-    }
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Double: JSONCodable {}
 
-}
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension UInt: JSONCodable {}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension UInt8: JSONCodable {}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension UInt16: JSONCodable {}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension UInt32: JSONCodable {}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension UInt64: JSONCodable {}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Int8: JSONCodable {}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Int16: JSONCodable {}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Int32: JSONCodable {}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Int64: JSONCodable {}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Float: JSONCodable {}
 
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
 extension String: JSONCodable {
@@ -276,136 +296,6 @@ extension UUID: JSONCodable {
             throw JSONError.uuidDecodingFailure(str)
         }
         self = uuid
-    }
-
-}
-
-@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension UInt: JSONCodable {
-
-    public func encodeToJSON() -> JSON {
-        JSON(Int(self))
-    }
-
-    public init(json: JSON) throws {
-        self = try UInt(json.intValue)
-    }
-
-}
-
-@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension UInt8: JSONCodable {
-
-    public func encodeToJSON() -> JSON {
-        JSON(Int(self))
-    }
-
-    public init(json: JSON) throws {
-        self = try UInt8(json.intValue)
-    }
-
-}
-
-@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension UInt16: JSONCodable {
-
-    public func encodeToJSON() -> JSON {
-        JSON(Int(self))
-    }
-
-    public init(json: JSON) throws {
-        self = try UInt16(json.intValue)
-    }
-
-}
-
-@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension UInt32: JSONCodable {
-
-    public func encodeToJSON() -> JSON {
-        JSON(Int(self))
-    }
-
-    public init(json: JSON) throws {
-        self = try UInt32(json.intValue)
-    }
-
-}
-
-@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension UInt64: JSONCodable {
-
-    public func encodeToJSON() -> JSON {
-        JSON(Int(self))
-    }
-
-    public init(json: JSON) throws {
-        self = try UInt64(json.intValue)
-    }
-
-}
-
-@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension Int8: JSONCodable {
-
-    public func encodeToJSON() -> JSON {
-        JSON(Int(self))
-    }
-
-    public init(json: JSON) throws {
-        self = try Int8(json.intValue)
-    }
-
-}
-
-@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension Int16: JSONCodable {
-
-    public func encodeToJSON() -> JSON {
-        JSON(Int(self))
-    }
-
-    public init(json: JSON) throws {
-        self = try Int16(json.intValue)
-    }
-
-}
-
-@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension Int32: JSONCodable {
-
-    public func encodeToJSON() -> JSON {
-        JSON(Int(self))
-    }
-
-    public init(json: JSON) throws {
-        self = try Int32(json.intValue)
-    }
-
-}
-
-@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension Int64: JSONCodable {
-
-    public func encodeToJSON() -> JSON {
-        JSON(Int(self))
-    }
-
-    public init(json: JSON) throws {
-        self = try Int64(json.intValue)
-    }
-
-}
-
-@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-extension Float: JSONCodable {
-
-    public func encodeToJSON() -> JSON {
-        JSON(Double(self))
-    }
-
-    public init(json: JSON) throws {
-        self = try Float(json.doubleValue)
     }
 
 }

--- a/Sources/JBirdCore/Protocols/JSONLiteralCodable.swift
+++ b/Sources/JBirdCore/Protocols/JSONLiteralCodable.swift
@@ -1,0 +1,77 @@
+// JBird
+// JSONLiteralCodable.swift
+//
+// MIT License
+//
+// Copyright (c) 2025 Varun Santhanam
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the  Software), to deal
+//
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED  AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/// A type that can convert itself into and out of an external `JSON.Literal` representation.
+///
+/// `JSONLiteralCodable` is a type alias for the `JSONLiteralEncodable` and `JSONLiteralDecodable` protocols.
+/// When you use `JSONLiteralCodable` as a type or a generic constraint, it matches any type that conforms to both protocols.
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+public typealias JSONLiteralCodable = JSONLiteralDecodable & JSONLiteralEncodable
+
+/// A type that can encode itself to an external  `JSON.Literal` representation.
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+public protocol JSONLiteralEncodable {
+
+    /// Encode this value to a typed `JSON.Literal` representation.
+    /// - Returns: The `JSON.Literal` value that represents the current instance.
+    func encodeToJSONLiteral() -> JSON.Literal
+
+}
+
+/// A type that can decode itself from an external `JSON.Literal` representation.
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+public protocol JSONLiteralDecodable {
+
+    /// Create an instance of the type from an externaled `JSON.Literal` representation.
+    /// - Parameter jsonLiteral: The `JSON.Literal` value to decode from.
+    init(jsonLiteral: JSON.Literal) throws
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Bool: JSONLiteralCodable {
+
+    public func encodeToJSONLiteral() -> JSON.Literal {
+        self ? .true : .false
+    }
+
+    public init(jsonLiteral: JSON.Literal) throws {
+        self = try jsonLiteral.boolValue
+    }
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension JSON.Literal: JSONLiteralCodable {
+
+    public func encodeToJSONLiteral() -> JSON.Literal {
+        self
+    }
+
+    public init(jsonLiteral: JSON.Literal) throws {
+        self = jsonLiteral
+    }
+
+}

--- a/Sources/JBirdCore/Protocols/JSONLiteralConvertible.swift
+++ b/Sources/JBirdCore/Protocols/JSONLiteralConvertible.swift
@@ -25,6 +25,7 @@
 
 /// A type that can be expressed as a JSON literal
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+@available(*, deprecated, renamed: "JSONLiteralEncodable", message: "Use JSONLiteralEncodable instead. This protocol will be removed in a future release.")
 public protocol JSONLiteralConvertible {
 
     /// The JSON literal representation of the value
@@ -33,6 +34,7 @@ public protocol JSONLiteralConvertible {
 }
 
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+@available(*, deprecated, renamed: "JSONLiteralEncodable", message: "Use JSONLiteralEncodable instead. This protocol will be removed in a future release.")
 extension Bool: JSONLiteralConvertible {
 
     public var jsonLiteral: JSON.Literal {

--- a/Sources/JBirdCore/Protocols/JSONNumberCodable.swift
+++ b/Sources/JBirdCore/Protocols/JSONNumberCodable.swift
@@ -1,0 +1,245 @@
+// JBird
+// JSONNumberCodable.swift
+//
+// MIT License
+//
+// Copyright (c) 2025 Varun Santhanam
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the  Software), to deal
+//
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED  AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/// A type that can convert itself into and out of an external `JSON.Number` representation.
+///
+/// `JSONNumberCodable` is a type alias for the `JSONNumberEncodable` and `JSONNumberDecodable` protocols.
+/// When you use `JSONNumberCodable` as a type or a generic constraint, it matches any type that conforms to both protocols.
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+public typealias JSONNumberCodable = JSONNumberDecodable & JSONNumberEncodable
+
+/// A type that can encode itself to an external  `JSON.Number` representation.
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+public protocol JSONNumberEncodable {
+
+    /// Encode this value to a typed `JSON.Number` representation.
+    /// - Returns: The `JSON.Number` value that represents the current instance.
+    func encodeToJSONNumber() -> JSON.Number
+
+}
+
+/// A type that can decode itself from an external `JSON.Number` representation.
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+public protocol JSONNumberDecodable {
+
+    /// Create an instance of the type from an externaled `JSON.Number` representation.
+    /// - Parameter jsonNumber: The `JSON.Number` value to decode from.
+    init(jsonNumber: JSON.Number) throws
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension JSON.Number: JSONNumberCodable {
+
+    public func encodeToJSONNumber() -> JSON.Number {
+        self
+    }
+
+    public init(jsonNumber: JSON.Number) throws {
+        self = jsonNumber
+    }
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Int: JSONNumberCodable {
+
+    public func encodeToJSONNumber() -> JSON.Number {
+        .int(self)
+    }
+
+    public init(jsonNumber: JSON.Number) throws {
+        switch jsonNumber {
+        case let .int(value):
+            self = value
+        case let .double(value):
+            if value.truncatingRemainder(dividingBy: 1.0) == 0,
+               let int = Int(exactly: value) {
+                self = int
+            } else {
+                throw JSONError.illegalNumberConversion
+            }
+        }
+    }
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Double: JSONNumberCodable {
+
+    public func encodeToJSONNumber() -> JSON.Number {
+        .double(self)
+    }
+
+    public init(jsonNumber: JSON.Number) throws {
+        switch jsonNumber {
+        case let .int(value):
+            self = Double(value)
+        case let .double(value):
+            self = value
+        }
+    }
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension UInt: JSONNumberCodable {
+
+    public func encodeToJSONNumber() -> JSON.Number {
+        .int(Int(self))
+    }
+
+    public init(jsonNumber: JSON.Number) throws {
+        let int = try Int(jsonNumber: jsonNumber)
+        self = UInt(int)
+    }
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension UInt8: JSONNumberCodable {
+
+    public func encodeToJSONNumber() -> JSON.Number {
+        .int(Int(self))
+    }
+
+    public init(jsonNumber: JSON.Number) throws {
+        let int = try Int(jsonNumber: jsonNumber)
+        self = UInt8(int)
+    }
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension UInt16: JSONNumberCodable {
+
+    public func encodeToJSONNumber() -> JSON.Number {
+        .int(Int(self))
+    }
+
+    public init(jsonNumber: JSON.Number) throws {
+        let int = try Int(jsonNumber: jsonNumber)
+        self = UInt16(int)
+    }
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension UInt32: JSONNumberCodable {
+
+    public func encodeToJSONNumber() -> JSON.Number {
+        .int(Int(self))
+    }
+
+    public init(jsonNumber: JSON.Number) throws {
+        let int = try Int(jsonNumber: jsonNumber)
+        self = UInt32(int)
+    }
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension UInt64: JSONNumberCodable {
+
+    public func encodeToJSONNumber() -> JSON.Number {
+        .int(Int(self))
+    }
+
+    public init(jsonNumber: JSON.Number) throws {
+        let int = try Int(jsonNumber: jsonNumber)
+        self = UInt64(int)
+    }
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Int8: JSONNumberCodable {
+
+    public func encodeToJSONNumber() -> JSON.Number {
+        .int(Int(self))
+    }
+
+    public init(jsonNumber: JSON.Number) throws {
+        let int = try Int(jsonNumber: jsonNumber)
+        self = Int8(int)
+    }
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Int16: JSONNumberCodable {
+
+    public func encodeToJSONNumber() -> JSON.Number {
+        .int(Int(self))
+    }
+
+    public init(jsonNumber: JSON.Number) throws {
+        let int = try Int(jsonNumber: jsonNumber)
+        self = Int16(int)
+    }
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Int32: JSONNumberCodable {
+
+    public func encodeToJSONNumber() -> JSON.Number {
+        .int(Int(self))
+    }
+
+    public init(jsonNumber: JSON.Number) throws {
+        let int = try Int(jsonNumber: jsonNumber)
+        self = Int32(int)
+    }
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Int64: JSONNumberCodable {
+
+    public func encodeToJSONNumber() -> JSON.Number {
+        .int(Int(self))
+    }
+
+    public init(jsonNumber: JSON.Number) throws {
+        let int = try Int(jsonNumber: jsonNumber)
+        self = Int64(int)
+    }
+
+}
+
+@available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension Float: JSONNumberCodable {
+
+    public func encodeToJSONNumber() -> JSON.Number {
+        .double(Double(self))
+    }
+
+    public init(jsonNumber: JSON.Number) throws {
+        let double = try Double(jsonNumber: jsonNumber)
+        self = Float(double)
+    }
+
+}

--- a/Sources/JBirdCore/Protocols/JSONNumericConvertible.swift
+++ b/Sources/JBirdCore/Protocols/JSONNumericConvertible.swift
@@ -25,6 +25,7 @@
 
 /// A type that can be represented as a JSON number
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+@available(*, deprecated, renamed: "JSONNumberEncodable", message: "Use JSONLiteralEncodable instead. This protocol will be removed in a future release.")
 public protocol JSONNumberConvertible {
 
     /// The JSON decimal number representation of the value
@@ -33,6 +34,7 @@ public protocol JSONNumberConvertible {
 }
 
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+@available(*, deprecated, renamed: "JSONNumberEncodable", message: "Use JSONLiteralEncodable instead. This protocol will be removed in a future release.")
 extension Int: JSONNumberConvertible {
 
     public var jsonNumber: JSON.Number {
@@ -42,6 +44,7 @@ extension Int: JSONNumberConvertible {
 }
 
 @available(macOS 13.0, macCatalyst 16.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+@available(*, deprecated, renamed: "JSONNumberEncodable", message: "Use JSONLiteralEncodable instead. This protocol will be removed in a future release.")
 extension Double: JSONNumberConvertible {
 
     public var jsonNumber: JSON.Number {

--- a/Tests/JBirdCoreTests/Models/LiteralTests.swift
+++ b/Tests/JBirdCoreTests/Models/LiteralTests.swift
@@ -98,11 +98,4 @@ struct LiteralTests {
         #expect(JSON.Literal.null.description == "null")
     }
 
-    @Test("RawValue Tests")
-    func rawValue() {
-        #expect(JSON.Literal.true.rawValue == "true")
-        #expect(JSON.Literal.false.rawValue == "false")
-        #expect(JSON.Literal.null.rawValue == "null")
-    }
-
 }

--- a/Tests/JBirdCoreTests/Protocols/JSONCodableTests.swift
+++ b/Tests/JBirdCoreTests/Protocols/JSONCodableTests.swift
@@ -146,6 +146,13 @@ struct JSONCodableTests {
             #expect(int == 21)
         }
 
+        @Test("Int As Double Decode")
+        func intDecodeAasDouble() throws {
+            let json = JSON.number(.int(21))
+            let double = try json.decode(into: Double.self)
+            #expect(double == 21.0)
+        }
+
     }
 
     @Suite("Double Conformance Tests")
@@ -163,6 +170,21 @@ struct JSONCodableTests {
             let json = JSON.number(.double(2.1))
             let double = try json.decode(into: Double.self)
             #expect(double == 2.1)
+        }
+
+        @Test("Double Decode As Int")
+        func doubleDecodeAsInt() throws {
+            let json = JSON.number(.double(4.0))
+            let int = try json.decode(into: Int.self)
+            #expect(int == 4)
+        }
+
+        @Test("Double Decode As Int Fails For Fractional Values")
+        func doubleDecodeAsIntFractionalFailure() {
+            let json = JSON.number(.double(4.1))
+            #expect(throws: JSONError.illegalNumberConversion) {
+                _ = try json.decode(into: Int.self)
+            }
         }
 
     }


### PR DESCRIPTION
- Introduce new `JSONNumberCodable` and `JSONLiteralCodable` protocols
- Deprecate `JSONNumberConvertible` and `JSONLiteralConvertible`
- Centralize the converstion of number types two and from their JSON intermediary representation types
- Allow int -> double and double -> int in certain situations
- Update unit tests
