### PR TITLE
Check for `NonisolatedNonsendingByDefault` before using @concurrent

### DIFF
--- a/Sources/JBirdCore/Models/JSON.swift
+++ b/Sources/JBirdCore/Models/JSON.swift
@@ -1118,7 +1118,7 @@ public enum JSON: Equatable, Hashable, Sendable, ExpressibleByBooleanLiteral, Ex
     }
 
     #if canImport(Darwin)
-        #if swift(>=6.2)
+        #if swift(>=6.2) && hasFeature(NonisolatedNonsendingByDefault)
             /// Write the JSON model to disk
             /// - Parameters:
             ///   - fileURL: The file URL to write to

--- a/Sources/JBirdCore/Serialization/Serialization.swift
+++ b/Sources/JBirdCore/Serialization/Serialization.swift
@@ -329,7 +329,7 @@ extension JSON {
         return Data(bytes)
     }
 
-    #if swift(>=6.2)
+    #if swift(>=6.2) && hasFeature(NonisolatedNonsendingByDefault)
         @concurrent
         private static func startSerializationAsync(
             from json: JSON,
@@ -769,7 +769,7 @@ extension JSON {
         return json
     }
 
-    #if swift(>=6.2)
+    #if swift(>=6.2) && hasFeature(NonisolatedNonsendingByDefault)
         @concurrent
         private static func parseAsync(
             _ data: Data,


### PR DESCRIPTION
Checking for this can be useful for consumer who are compiling the library from source in their own environments, are using Swift 6.2, but are *not* yet using `NonisolatedNonsendingByDefault`