### PR TITLE
Remove explicit platform from scheme in SPI manifest

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,7 +1,6 @@
 version: 1
 builder:
   configs:
-  - platform: macOS
-    scheme: JBird
+  - scheme: JBird
 external_links:
   documentation: "https://www.usejbird.com/docs/documentation/jbird/"


### PR DESCRIPTION
Remove `macOS` from `.spi.yml`, per suggestion from the SPI team