### PR TITLE
Support JSONRepresentable macro on nested declarations

### DIFF
--- a/Sources/JBirdMacrosCompilerPlugin/JSONRepresentableMacro.swift
+++ b/Sources/JBirdMacrosCompilerPlugin/JSONRepresentableMacro.swift
@@ -42,15 +42,11 @@ public struct JSONRepresentableMacro: ExtensionMacro, MemberMacro {
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
 
-        let name: String
+        let name = type.trimmedDescription
 
-        if let structDecl = declaration.as(StructDeclSyntax.self) {
-            name = structDecl.name.text
-        } else if let classDecl = declaration.as(ClassDeclSyntax.self) {
-            name = classDecl.name.text
-        } else if let enumDecl = declaration.as(EnumDeclSyntax.self) {
-            name = enumDecl.name.text
-        } else {
+        if !declaration.is(StructDeclSyntax.self),
+           !declaration.is(ClassDeclSyntax.self),
+           !declaration.is(EnumDeclSyntax.self) {
             throw MacroExpansionErrorMessage("@JSONRepresentable macro can only be applied to structs, enums or classes.")
         }
 

--- a/Tests/JBirdMacrosCompilerPluginTests/JSONRepresentableMacroTests.swift
+++ b/Tests/JBirdMacrosCompilerPluginTests/JSONRepresentableMacroTests.swift
@@ -600,4 +600,74 @@ struct JSONRepresentableMacroTests {
         #endif
     }
 
+    @Test("Nested Declaration")
+    func nestedDeclaration() {
+        #if canImport(JBirdMacrosCompilerPlugin)
+            assertMacroExpansion(
+                """
+                @JSONRepresentable
+                struct Foo {
+
+                    let bar: Bar
+
+                    @JSONRepresentable
+                    final class Bar {
+
+                        let name: String
+
+                    }
+
+                }
+                """,
+                expandedSource: """
+                struct Foo {
+
+                    let bar: Bar
+                    final class Bar {
+
+                        let name: String
+
+                        @JBirdCore.JSON.Builder
+                        public var jsonValue: JBirdCore.JSON {
+                            "name" => name
+                        }
+
+                        public init(json: JSON) throws {
+                            self.name = try json["name"]
+                        }
+
+                    }
+
+                    @JBirdCore.JSON.Builder
+                    public var jsonValue: JBirdCore.JSON {
+                        "bar" => bar
+                    }
+
+                    public init(json: JSON) throws {
+                        self.bar = try json["bar"]
+                    }
+
+                }
+
+                extension Foo.Bar: JBirdCore.JSONConvertible {
+                }
+
+                extension Foo.Bar: JBirdCore.JSONInitializable {
+                }
+
+                extension Foo: JBirdCore.JSONConvertible {
+                }
+
+                extension Foo: JBirdCore.JSONInitializable {
+                }
+                """,
+                macroSpecs: macroSpecs
+            ) { failure in
+                Issue.record("An unexpected failure occured")
+            }
+        #else
+            Issue.record("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
 }

--- a/Tests/JBirdMacrosTests/JBirdMacrosTests.swift
+++ b/Tests/JBirdMacrosTests/JBirdMacrosTests.swift
@@ -127,6 +127,18 @@ struct JSONRepresentableTests {
 
     }
 
+    @Test("@JSONRepresentable Nesting Support")
+    func nestingSupport() throws {
+        let model = NestingOuter(inner: .init(name: "nesting"))
+        let json = JSON(model)
+        let decoded = try NestingOuter(json: json)
+        #expect(model == decoded)
+        #expect(json == [
+            "inner": [
+                "name": "nesting"
+            ]
+        ])
+    }
 }
 
 @JSONRepresentable
@@ -198,3 +210,29 @@ class TestClass {
 }
 
 final class TestSubClass: TestClass {}
+
+@JSONRepresentable
+struct NestingOuter: Equatable {
+
+    let inner: NestingInner
+
+    init(inner: NestingInner) {
+        self.inner = inner
+    }
+
+    @JSONRepresentable
+    final class NestingInner: Equatable {
+
+        let name: String
+
+        init(name: String) {
+            self.name = name
+        }
+
+        static func == (lhs: NestingInner, rhs: NestingInner) -> Bool {
+            lhs.name == rhs.name
+        }
+
+    }
+
+}


### PR DESCRIPTION
Thank you for creating and maintaining JBird. The library fits my use case very well and has made JSON serialization much more convenient.

This change adds support for applying `@JSONRepresentable` to nested structs, classes, and enums.

Currently, the macro derives the extension target from the declaration’s local name. For a nested declaration such as:

```swift
@JSONRepresentable
struct Foo {
    @JSONRepresentable
    final class Bar {
        let name: String
    }
}
```

the generated extension incorrectly refers to `Bar` at file scope:

```swift
// Should be Foo.Bar
extension Bar: JBirdCore.JSONConvertible {
}
```

Inspired by Swift’s [`@Observable`](https://github.com/swiftlang/swift/blob/064859e41d68596f486c5d724401cb370f260409/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift#L399), the generated conformances now use the extended type provided by the macro expansion context, preserving the enclosing declaration path.

A macro expansion test is included to cover member generation and fully qualified conformances for nested declarations.